### PR TITLE
HDDS-1578. Add libstdc++ to ozone build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN apk --no-cache add ca-certificates wget && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && \
     apk add glibc-2.28-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-bin-2.28-r0.apk && \
+    apk add glibc-bin-2.28-r0.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-i18n-2.28-r0.apk && \
+    apk add glibc-i18n-2.28-r0.apk && \
 
 #Install protobuf
 RUN mkdir -p /usr/local/src/ && \


### PR DESCRIPTION
libstdc++ is required for node install in alpine builds. Otherwise we get this error:

[ERROR] node: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory