### PR TITLE
HDDS-2025. Update the base image of the apache/ozone and use latest 0.4.1 release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/ozone-runner:20190717-1
-ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.4.0-alpha/hadoop-ozone-0.4.0-alpha.tar.gz
+ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.4.1-alpha/hadoop-ozone-0.4.1-alpha.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/hadoop-runner
+FROM apache/ozone-runner:20190717-1
 ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.4.0-alpha/hadoop-ozone-0.4.0-alpha.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop

--- a/build.sh
+++ b/build.sh
@@ -18,11 +18,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 mkdir -p build
 if [ ! -d "$DIR/build/apache-rat-0.12" ]; then
-   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.12/apache-rat-0.12-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
 	cd $DIR/build
 	tar zvxf apache-rat.tar.gz
 	cd -
 fi
-java -jar $DIR/build/apache-rat-0.12/apache-rat-0.12.jar $DIR -e .dockerignore -e public -e apache-rat-0.12 -e .git -e .gitignore
+java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build -t apache/ozone .
 docker tag apache/ozone apache/ozone:0.4.0-alpha

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       command: ["ozone","datanode"]
       env_file:
         - ./docker-config
-   ozoneManager:
+   om:
       image: apache/ozone:0.4.0
       ports:
          - 9874:9874

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:0.4.0
+      image: apache/ozone:0.4.1
       ports:
         - 9864
       command: ["ozone","datanode"]
       env_file:
         - ./docker-config
    om:
-      image: apache/ozone:0.4.0
+      image: apache/ozone:0.4.1
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:0.4.0
+      image: apache/ozone:0.4.1
       ports:
          - 9876:9876
       env_file:
@@ -43,7 +43,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    s3g:
-      image: apache/ozone:0.4.0
+      image: apache/ozone:0.4.1
       ports:
          - 9878:9878
       env_file:

--- a/start-ozone-all.sh
+++ b/start-ozone-all.sh
@@ -22,7 +22,7 @@ ozone datanode &
 #wait for scm startup
 export WAITFOR=localhost:9876
 
-/opt/starter.sh ozone om --init
-/opt/starter.sh ozone om &
+/opt/hadoop/bin/docker/entrypoint.sh ozone om --init
+/opt/hadoop/bin/docker/entrypoint.sh ozone om &
 sleep 15
-/opt/starter.sh ozone s3g
+/opt/hadoop/bin/docker/entrypoint.sh ozone s3g


### PR DESCRIPTION
The hadoop-docker-ozone repository contains the definition of the apache/ozone image.

https://github.com/apache/hadoop-docker-ozone/tree/ozone-latest

It creates a docker packaging for the voted and released artifact, therefore it can be released after the final vote.

Since the latest release we did some modification in our Dockerfiles. We need to apply the changes to the official image as well. Especially:

1. use ozone-runner as a base image instead of hadoop-runner
2. rename ozoneManager service to om as we did everywhere
3. Adjust the starter location (the script is moved to the released tar file)