### PR TITLE
HDDS-1701. Move dockerbin script to libexec.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /opt/profiler && \
 
 ENV JAVA_HOME=/usr/lib/jvm/jre/
 
-ENV PATH /opt/hadoop/bin/docker:$PATH:/opt/hadoop/bin
+ENV PATH /opt/hadoop/libexec:$PATH:/opt/hadoop/bin
 
 RUN groupadd --gid 1000 hadoop
 RUN useradd --uid 1000 hadoop --gid 100 --home /opt/hadoop


### PR DESCRIPTION
## What changes were proposed in this pull request?

Relocate the docker scripts in dist.

But the changed Dockerfile in ```apache/hadoop-ozone``` is used only to create images for k8s deployment,
so we should update it in this repository.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-1701