### PR TITLE
HDDS-2308. Switch to centos with the apache/ozone-build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,24 +12,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM docker:18.09.1
-RUN apk add --update --no-cache bash alpine-sdk maven jq grep openjdk8 py-pip rsync procps autoconf automake libtool findutils coreutils
-
-#Install real glibc
-RUN apk --no-cache add ca-certificates wget && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && \
-    apk add glibc-2.28-r0.apk && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-bin-2.28-r0.apk && \
-    apk add glibc-bin-2.28-r0.apk && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-i18n-2.28-r0.apk && \
-    apk add glibc-i18n-2.28-r0.apk
+FROM centos:7.6.1810
+RUN yum -y install epel-release
+RUN yum -y install gcc gcc-c++ kernel-devel make autoconf automake libtool which \
+   java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel\
+   docker \
+   python-pip \ 
+   file python-devel \
+   git \
+   jq \
+   sudo
 
 #Install protobuf
+ENV LD_LIBRARY_PATH=/usr/lib
 RUN mkdir -p /usr/local/src/ && \
     cd /usr/local/src/ && \
-    wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz && \
-    tar xvf protobuf-2.5.0.tar.gz && \
+    curl -sL https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz | tar xz && \
     cd protobuf-2.5.0 && \
     ./autogen.sh && \
     ./configure --prefix=/usr && \
@@ -47,40 +45,23 @@ RUN mkdir -p /opt && \
     curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=/ant/binaries/apache-ant-1.10.7-bin.tar.gz' | tar -xz  && \
        mv apache-ant* /opt/ant
 
+#Install apache-maven
+RUN curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz' | tar -xz  && \
+        mv apache-maven* /opt/maven
+
 #Install docker-compose (for smoketests)
-RUN apk add --no-cache libffi-dev libressl-dev python-dev
 RUN pip install --upgrade pip
 RUN pip install docker-compose
 
-ENV PATH=$PATH:/opt/findbugs/bin
+ENV PATH=$PATH:/opt/findbugs/bin:/opt/maven/bin:/opt/ant/bin
 
 #This is a dirty but powerful hack. We don't know which uid will be used inside the container.
 #But for the kerberized unit test we need real users. We assume that the uid will be something 
 # between 1 and 5000 and generate all the required users in advance.
-RUN addgroup -g 1000 default && \
+RUN groupadd -g 1000 default && \
    mkdir -p /home/user && \
    chmod 777 /home/user && \
-   for i in $(seq 1 5000); do adduser jenkins$i -u $i -G default -h /home/user -H -D; done
-
-#This is a very huge local maven cache. Usually the mvn repository is not safe to be 
-#shared between builds as concurrent "mvn install" executions are not handled very well.
-#A simple workaround is to provide all the required 3rd party lib in the docker image
-#It will be cached by docker, and any additional dependency can be downloaded, artifacts
-#can be installed
-#
-#To be sure that we have no dev bits from this build, we will remove org.apache.hadoop files
-#from the local maven repository.
-USER jenkins1000
-RUN cd /tmp && \
-   git clone --depth=1 https://github.com/apache/hadoop.git -b trunk && \
-   cd /tmp/hadoop && \
-   mvn package dependency:go-offline -DskipTests -f pom.ozone.xml && \
-   rm -rf /home/user/.m2/repository/org/apache/hadoop/*hdds* && \
-   rm -rf /home/user/.m2/repository/org/apache/hadoop/*ozone* && \
-   rm -rf /tmp/hadoop && \
-   find /home/user/.m2/repository -exec chmod o+wx {} \;
-
-USER root
+   for i in $(seq 1 5000); do adduser jenkins$i -u $i -g default -d /home/user -N; done
 
 RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
@@ -99,4 +80,22 @@ RUN pip install robotframework
 
 RUN curl -sL https://github.com/muquit/mailsend-go/releases/download/v1.0.5/mailsend-go_1.0.5_linux-64bit.tar.gz | tar zxf - && mv mailsend-go-dir/mailsend-go /usr/local/bin/ && rm -rf mailsend-go-dir
 
+RUN curl -L https://github.com/elek/flekszible/releases/download/v1.5.2/flekszible_1.5.2_Linux_x86_64.tar.gz | tar zx && mv flekszible /usr/local/bin && chmod +x /usr/local/bin/flekszible
+
 USER jenkins1000
+
+#This is a very huge local maven cache. Usually the mvn repository is not safe to be 
+#shared between builds as concurrent "mvn install" executions are not handled very well.
+#A simple workaround is to provide all the required 3rd party lib in the docker image
+#It will be cached by docker, and any additional dependency can be downloaded, artifacts
+#can be installed
+#
+#To be sure that we have no dev bits from this build, we will remove org.apache.hadoop files
+#from the local maven repository.
+
+RUN cd /tmp && git clone --depth=1 https://github.com/apache/hadoop.git -b trunk && \
+   cd /tmp/hadoop && mvn -B package dependency:go-offline -DskipTests=true -f pom.ozone.xml && \
+   rm -rf /home/user/.m2/repository/org/apache/hadoop/*hdds* && \
+   rm -rf /home/user/.m2/repository/org/apache/hadoop/*ozone* && \
+   rm -rf /tmp/hadoop && \ 
+   find /home/user/.m2/repository -exec chmod go+wx {} \;


### PR DESCRIPTION
## What changes were proposed in this pull request?

I realized multiple JVM crashes in the daily builds:

``` 
ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called? 
        [ERROR] Command was /bin/sh -c cd /workdir/hadoop-ozone/ozonefs && /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -jar /workdir/hadoop-ozone/ozonefs/target/surefire/surefirebooter9018689154779946208.jar /workdir/hadoop-ozone/ozonefs/target/surefire 2019-10-06T14-52-40_697-jvmRun1 surefire7569723928289175829tmp surefire_947955725320624341206tmp
        [ERROR] Error occurred in starting fork, check output in log
        [ERROR] Process Exit Code: 139
        [ERROR] Crashed tests:
        [ERROR] org.apache.hadoop.fs.ozone.contract.ITestOzoneContractRename
        [ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
        [ERROR] Command was /bin/sh -c cd /workdir/hadoop-ozone/ozonefs && /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -jar /workdir/hadoop-ozone/ozonefs/target/surefire/surefirebooter5429192218879128313.jar /workdir/hadoop-ozone/ozonefs/target/surefire 2019-10-06T14-52-40_697-jvmRun1 surefire7227403571189445391tmp surefire_1011197392458143645283tmp
        [ERROR] Error occurred in starting fork, check output in log
        [ERROR] Process Exit Code: 139
        [ERROR] Crashed tests:
        [ERROR] org.apache.hadoop.fs.ozone.contract.ITestOzoneContractDistCp
        [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
        [ERROR] Command was /bin/sh -c cd /workdir/hadoop-ozone/ozonefs && /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -jar /workdir/hadoop-ozone/ozonefs/target/surefire/surefirebooter1355604543311368443.jar /workdir/hadoop-ozone/ozonefs/target/surefire 2019-10-06T14-52-40_697-jvmRun1 surefire3938612864214747736tmp surefire_933162535733309260236tmp
        [ERROR] Error occurred in starting fork, check output in log
        [ERROR] Process Exit Code: 139
        [ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
        [ERROR] Command was /bin/sh -c cd /workdir/hadoop-ozone/ozonefs && /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -jar /workdir/hadoop-ozone/ozonefs/target/surefire/surefirebooter9018689154779946208.jar /workdir/hadoop-ozone/ozonefs/target/surefire 2019-10-06T14-52-40_697-jvmRun1 surefire7569723928289175829tmp surefire_947955725320624341206tmp
        [ERROR] Error occurred in starting fork, check output in log
        [ERROR] Process Exit Code: 139 
``` 

Based on the crash log (uploaded) it's related to the rocksdb JNI interface.

In the current ozone-build docker image (which provides the environment for build) we use alpine where musl libc is used instead of the main glibc. I think it would be more safe to use the same glibc what is used in production.

I tested with centos based docker image and it seems to be more stable. Didn't see any more JVM crashes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2308

## How this patch can be tested?

Built and pushed to my own dockerhub account:

```
docker build -t elek/ozone-build:20191106-1 .
docker puseh elek/ozone-build:20191106-1
```

And used in the PR builds.