### PR TITLE
HDDS-2859. Install Hugo framework, cache Ozone repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,9 +93,9 @@ USER jenkins1000
 #To be sure that we have no dev bits from this build, we will remove org.apache.hadoop files
 #from the local maven repository.
 
-RUN cd /tmp && git clone --depth=1 https://github.com/apache/hadoop.git -b trunk && \
-   cd /tmp/hadoop && mvn -B package dependency:go-offline -DskipTests=true -f pom.ozone.xml && \
+RUN cd /tmp && git clone --depth=1 https://github.com/apache/hadoop-ozone.git -b master && \
+   cd /tmp/hadoop-ozone && mvn -B package dependency:go-offline -DskipTests=true && \
    rm -rf /home/user/.m2/repository/org/apache/hadoop/*hdds* && \
    rm -rf /home/user/.m2/repository/org/apache/hadoop/*ozone* && \
-   rm -rf /tmp/hadoop && \ 
+   rm -rf /tmp/hadoop-ozone && \
    find /home/user/.m2/repository -exec chmod go+wx {} \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ RUN curl -sL https://github.com/muquit/mailsend-go/releases/download/v1.0.5/mail
 
 RUN curl -L https://github.com/elek/flekszible/releases/download/v1.5.2/flekszible_1.5.2_Linux_x86_64.tar.gz | tar zx && mv flekszible /usr/local/bin && chmod +x /usr/local/bin/flekszible
 
+RUN curl -LSs https://github.com/gohugoio/hugo/releases/download/v0.62.2/hugo_0.62.2_Linux-64bit.tar.gz | tar zxf - hugo && mv hugo /usr/local/bin/ && chmod +x /usr/local/bin/hugo
+
 USER jenkins1000
 
 #This is a very huge local maven cache. Usually the mvn repository is not safe to be 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Install Hugo (to be able to validate Ozone docs in CI)
2. Cache Ozone repo instead of Hadoop

## How was this patch tested?

Tested both changed commands separately:

1. Hugo install in a `centos:7.6.1810` container
2. Maven cache command in `elek/ozone-build:20191106-1`