### PR TITLE
HDDS-3332. Upgrade to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@
 
 FROM centos@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973a9673822d1414824a1d0475
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y sudo python2-pip wget nmap-ncat jq java-11-openjdk
+RUN yum install -y sudo python3 python3-pip wget nmap-ncat jq java-11-openjdk
 
 #For executing inline smoketest
-RUN pip install robotframework
+RUN pip3 install robotframework
 
 #dumb init for proper init handling
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
@@ -48,6 +48,7 @@ RUN chown hadoop /opt
 #Be prepared for kerbebrizzed cluster
 RUN mkdir -p /etc/security/keytabs && chmod -R a+wr /etc/security/keytabs 
 ADD krb5.conf /etc/
+RUN chmod 644 /etc/krb5.conf
 RUN yum install -y krb5-workstation
 
 # CSI / k8s / fuse / goofys dependency
@@ -61,9 +62,11 @@ ENV HADOOP_LOG_DIR=/var/log/hadoop
 ENV HADOOP_CONF_DIR=/etc/hadoop
 RUN mkdir /data && chmod 1777 /data
 
+#default entrypoint (used only if the ozone dir is not bindmounted)
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+
 WORKDIR /opt/hadoop
 USER hadoop
 
-#default entrypoint (used only if the ozone dir is not bindmounted)
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "entrypoint.sh"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ozone Runner image to Python 3 to get better timeout behavior in Robot Framework.  It seems with Python 3 the framework is able to actually kill runaway commands.

https://issues.apache.org/jira/browse/HDDS-3332

## How was this patch tested?

Built image locally:

```
docker build -t apache/ozone-runner:python3 .
```

Executed `ozone-topology` acceptance test with [a small patch](https://github.com/adoroszlai/hadoop-ozone/commit/d3650b49787c36bb7f4c9585fc19e799ef51a169) to make the invocation of Robot Framework independent from Python version:

```
export OZONE_RUNNER_VERSION=python3
cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/compose/ozone-topology
./test.sh
```

Verified that Python 3 is being used:

```
$ docker-compose exec -T scm ps aux | grep robot
... /usr/bin/python3 /usr/local/bin/robot --log NONE -N ozone-topology-basic --report NONE --output /tmp/smoketest/ozone-topology/result/robot-ozone-topology-ozone-topology-basic-scm.xml /opt/hadoop/smoketest/basic/basic.robot
```