### PR TITLE
HDDS-3688. Create docker image for 0.5.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20190717-1
-ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.4.1-alpha/hadoop-ozone-0.4.1-alpha.tar.gz
+FROM apache/ozone-runner:20191107-1
+ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.5.0-beta/hadoop-ozone-0.5.0-beta.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop
-ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
-ADD ozone-site.xml /opt/hadoop/etc/hadoop/ozone-site.xml
-RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*
-ADD start-ozone-all.sh /usr/local/bin/start-ozone-all.sh
-ADD docker-compose.yaml /opt/hadoop/
-ADD docker-config /opt/hadoop/
+COPY log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
+COPY ozone-site.xml /opt/hadoop/etc/hadoop/ozone-site.xml
+RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop
+COPY --chown=hadoop:users start-ozone-all.sh /usr/local/bin/
+COPY --chown=hadoop:users docker-compose.yaml /opt/hadoop/
+COPY --chown=hadoop:users docker-config /opt/hadoop/
 CMD ["/usr/local/bin/start-ozone-all.sh"]

--- a/build.sh
+++ b/build.sh
@@ -15,14 +15,20 @@
 # limitations under the License.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-set -e
+set -eu
 mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.12" ]; then
-   wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
-	cd $DIR/build
-	tar zvxf apache-rat.tar.gz
-	cd -
+if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
+  if type wget 2> /dev/null; then
+    wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+  elif type curl 2> /dev/null; then
+    curl -LSs "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+  else
+    exit 1
+  fi
+  cd $DIR/build
+  tar zvxf apache-rat.tar.gz
+  cd -
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
-docker build -t apache/ozone .
-docker tag apache/ozone apache/ozone:0.4.0-alpha
+docker build --build-arg OZONE_URL -t apache/ozone .
+docker tag apache/ozone apache/ozone:0.5.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,35 +17,42 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:0.4.1
+      image: apache/ozone:0.5.0
       ports:
-        - 9864
+         - 9864
       command: ["ozone","datanode"]
       env_file:
-        - ./docker-config
+         - ./docker-config
    om:
-      image: apache/ozone:0.4.1
+      image: apache/ozone:0.5.0
       ports:
          - 9874:9874
       environment:
-         ENSURE_OM_INITIALIZED: /data/metadata/ozoneManager/current/VERSION
+         ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
          WAITFOR: scm:9876
       env_file:
-          - ./docker-config
+         - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:0.4.1
+      image: apache/ozone:0.5.0
       ports:
          - 9876:9876
       env_file:
-          - ./docker-config
+         - ./docker-config
       environment:
-          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+         ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
+   recon:
+      image: apache/ozone:0.5.0
+      ports:
+         - 9888:9888
+      env_file:
+         - ./docker-config
+      command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:0.4.1
+      image: apache/ozone:0.5.0
       ports:
          - 9878:9878
       env_file:
-          - ./docker-config
+         - ./docker-config
       command: ["ozone","s3g"]

--- a/docker-config
+++ b/docker-config
@@ -15,65 +15,16 @@
 # limitations under the License.
 
 OZONE-SITE.XML_ozone.om.address=om
+OZONE-SITE.XML_ozone.om.http-address=om:9874
 OZONE-SITE.XML_ozone.scm.names=scm
-OZONE-SITE.XML_ozone.enabled=true
-OZONE-SITE.XML_ozone.scm.datanode.id=/data/datanode.id
+OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
 OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.replication=1
+OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_ozone.recon.address=recon:9891
 
-HDFS-SITE.XML_rpc.metrics.quantile.enable=true
-HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
-LOG4J.PROPERTIES_log4j.rootLogger=INFO, stdout
-LOG4J.PROPERTIES_log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-LOG4J.PROPERTIES_log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-LOG4J.PROPERTIES_log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-LOG4J.PROPERTIES_log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
-LOG4J.PROPERTIES_log4j.logger.org.apache.ratis.conf.ConfUtils=WARN
-LOG4J.PROPERTIES_log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
-LOG4J.PROPERTIES_log4j.logger.http.requests.s3gateway=INFO,s3gatewayrequestlog
-LOG4J.PROPERTIES_log4j.appender.s3gatewayrequestlog=org.apache.hadoop.http.HttpRequestLogAppender
-LOG4J.PROPERTIES_log4j.appender.s3gatewayrequestlog.Filename=/tmp/jetty-s3gateway-yyyy_mm_dd.log
-LOG4J.PROPERTIES_log4j.appender.s3gatewayrequestlog.RetainDays=3
-
-#Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
-#BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
-
-#LOG4J2.PROPERTIES_* are for Ozone Audit Logging
-LOG4J2.PROPERTIES_monitorInterval=30
-LOG4J2.PROPERTIES_filter=read,write
-LOG4J2.PROPERTIES_filter.read.type=MarkerFilter
-LOG4J2.PROPERTIES_filter.read.marker=READ
-LOG4J2.PROPERTIES_filter.read.onMatch=DENY
-LOG4J2.PROPERTIES_filter.read.onMismatch=NEUTRAL
-LOG4J2.PROPERTIES_filter.write.type=MarkerFilter
-LOG4J2.PROPERTIES_filter.write.marker=WRITE
-LOG4J2.PROPERTIES_filter.write.onMatch=NEUTRAL
-LOG4J2.PROPERTIES_filter.write.onMismatch=NEUTRAL
-LOG4J2.PROPERTIES_appenders=console, rolling
-LOG4J2.PROPERTIES_appender.console.type=Console
-LOG4J2.PROPERTIES_appender.console.name=STDOUT
-LOG4J2.PROPERTIES_appender.console.layout.type=PatternLayout
-LOG4J2.PROPERTIES_appender.console.layout.pattern=%d{DEFAULT} | %-5level | %c{1} | %msg | %throwable{3} %n
-LOG4J2.PROPERTIES_appender.rolling.type=RollingFile
-LOG4J2.PROPERTIES_appender.rolling.name=RollingFile
-LOG4J2.PROPERTIES_appender.rolling.fileName=${sys:hadoop.log.dir}/om-audit-${hostName}.log
-LOG4J2.PROPERTIES_appender.rolling.filePattern=${sys:hadoop.log.dir}/om-audit-${hostName}-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
-LOG4J2.PROPERTIES_appender.rolling.layout.type=PatternLayout
-LOG4J2.PROPERTIES_appender.rolling.layout.pattern=%d{DEFAULT} | %-5level | %c{1} | %msg | %throwable{3} %n
-LOG4J2.PROPERTIES_appender.rolling.policies.type=Policies
-LOG4J2.PROPERTIES_appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-LOG4J2.PROPERTIES_appender.rolling.policies.time.interval=86400
-LOG4J2.PROPERTIES_appender.rolling.policies.size.type=SizeBasedTriggeringPolicy
-LOG4J2.PROPERTIES_appender.rolling.policies.size.size=64MB
-LOG4J2.PROPERTIES_loggers=audit
-LOG4J2.PROPERTIES_logger.audit.type=AsyncLogger
-LOG4J2.PROPERTIES_logger.audit.name=OMAudit
-LOG4J2.PROPERTIES_logger.audit.level=INFO
-LOG4J2.PROPERTIES_logger.audit.appenderRefs=rolling
-LOG4J2.PROPERTIES_logger.audit.appenderRef.file.ref=RollingFile
-LOG4J2.PROPERTIES_rootLogger.level=INFO
-LOG4J2.PROPERTIES_rootLogger.appenderRefs=stdout
-LOG4J2.PROPERTIES_rootLogger.appenderRef.stdout.ref=STDOUT
+no_proxy=om,recon,scm,s3g,localhost,127.0.0.1

--- a/ozone-site.xml
+++ b/ozone-site.xml
@@ -16,10 +16,11 @@
 -->
 <configuration>
 <property><name>ozone.scm.block.client.address</name><value>localhost</value></property>
-<property><name>ozone.enabled</name><value>True</value></property>
 <property><name>ozone.scm.datanode.id</name><value>/tmp/datanode.id</value></property>
 <property><name>ozone.scm.client.address</name><value>localhost</value></property>
 <property><name>ozone.metadata.dirs</name><value>/tmp/metadata</value></property>
 <property><name>ozone.scm.names</name><value>localhost</value></property>
 <property><name>ozone.om.address</name><value>localhost</value></property>
+<property><name>ozone.recon.db.dir</name><value>/tmp/metadata/recon</value></property>
+<property><name>ozone.recon.address</name><value>localhost:9891</value></property>
 </configuration>

--- a/start-ozone-all.sh
+++ b/start-ozone-all.sh
@@ -22,7 +22,8 @@ ozone datanode &
 #wait for scm startup
 export WAITFOR=localhost:9876
 
-/opt/hadoop/bin/docker/entrypoint.sh ozone om --init
-/opt/hadoop/bin/docker/entrypoint.sh ozone om &
+/opt/hadoop/libexec/entrypoint.sh ozone om --init
+/opt/hadoop/libexec/entrypoint.sh ozone om &
 sleep 15
-/opt/hadoop/bin/docker/entrypoint.sh ozone s3g
+/opt/hadoop/libexec/entrypoint.sh ozone recon &
+/opt/hadoop/libexec/entrypoint.sh ozone s3g


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update docker build scripts and config files for Ozone 0.5.0.

* Use more recent runner with updated `PATH` (for HDDS-1701)
* Add `recon`
* Remove `ozone.enabled` (HDDS-2366)
* Remove `log4j` and audit config (HDDS-2217)
* Add `no_proxy` config (HDDS-2814)

https://issues.apache.org/jira/browse/HDDS-3688

## How was this patch tested?

Ran smoke test (Freon key create and validate) on both all-in-one and compose cluster.