### PR TITLE
HDDS-4203. Publish apache/ozone:1.0.0 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/ozone-runner:20191107-1
-ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-0.5.0-beta/hadoop-ozone-0.5.0-beta.tar.gz
+ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -31,4 +31,4 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build --build-arg OZONE_URL -t apache/ozone .
-docker tag apache/ozone apache/ozone:0.5.0
+docker tag apache/ozone apache/ozone:1.0.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:0.5.0
+      image: apache/ozone:1.0.0
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:0.5.0
+      image: apache/ozone:1.0.0
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:0.5.0
+      image: apache/ozone:1.0.0
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:0.5.0
+      image: apache/ozone:1.0.0
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:0.5.0
+      image: apache/ozone:1.0.0
       ports:
          - 9878:9878
       env_file:

--- a/start-ozone-all.sh
+++ b/start-ozone-all.sh
@@ -17,10 +17,10 @@
 ozone scm --init
 ozone scm &
 
-ozone datanode &
-
 #wait for scm startup
 export WAITFOR=localhost:9876
+
+/opt/hadoop/libexec/entrypoint.sh ozone datanode &
 
 /opt/hadoop/libexec/entrypoint.sh ozone om --init
 /opt/hadoop/libexec/entrypoint.sh ozone om &


### PR DESCRIPTION
Publish official docker image for ozone 1.0.0

## How is it tested

```
./build.sh
```

```
docker run -p 9876:9876 apache/ozone:1.0.0
# checked the 9876 and number of datanodes
```

```
docker run apache/ozone:1.0.0 cat docker-config > docker-config
docker run apache/ozone:1.0.0 cat docker-compose.yaml > docker-compose.yaml
docker-compose up -d
# checked the 9876 and number of datanodes
```