### PR TITLE
HDDS-6015. Publish docker image for Ozone 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20191107-1
-ARG OZONE_URL=https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz
+FROM apache/ozone-runner:20210329-1
+ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 FROM apache/ozone-runner:20210329-1
 ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0.tar.gz
 WORKDIR /opt
-RUN sudo rm -rf /opt/hadoop && wget $OZONE_URL -O ozone.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
+RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop
 COPY log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 COPY ozone-site.xml /opt/hadoop/etc/hadoop/ozone-site.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20210329-1
+FROM apache/ozone-runner:20210520-1
 ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Ozone
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/build.sh
+++ b/build.sh
@@ -19,9 +19,9 @@ set -eu
 mkdir -p build
 if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
   if type wget 2> /dev/null; then
-    wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+    wget "https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
   elif type curl 2> /dev/null; then
-    curl -LSs "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+    curl -LSs "https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
   else
     exit 1
   fi
@@ -31,4 +31,4 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build --build-arg OZONE_URL -t apache/ozone .
-docker tag apache/ozone apache/ozone:1.0.0
+docker tag apache/ozone apache/ozone:1.2.0

--- a/build.sh
+++ b/build.sh
@@ -30,5 +30,5 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
   cd -
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
-docker build --build-arg OZONE_URL -t apache/ozone .
+docker build --build-arg OZONE_URL -t apache/ozone $@ .
 docker tag apache/ozone apache/ozone:1.2.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:1.0.0
+      image: apache/ozone:1.2.0
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:1.0.0
+      image: apache/ozone:1.2.0
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:1.0.0
+      image: apache/ozone:1.2.0
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:1.0.0
+      image: apache/ozone:1.2.0
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:1.0.0
+      image: apache/ozone:1.2.0
       ports:
          - 9878:9878
       env_file:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update dockerfile etc. for building with recently released version 1.2.0.

https://issues.apache.org/jira/browse/HDDS-6015

## How was this patch tested?

Built locally:

```
$ ./build.sh
...
 => => writing image sha256:8b2eadd31396a9788b94dc346e92d9393c79ab9cafb97f32fdefd96ceac5aeab
 => => naming to docker.io/apache/ozone                                                     
```

Tested:

```
$ docker-compose up -d --scale datanode=3
$ docker-compose exec om ozone version
...
              /    1.2.0(Glacier)

Source code repository https://github.com/apache/ozone.git -r 9ee6f1872dca8469057d3c7bf880931c0e7b7f3e
Compiled by ethanrose on 2021-11-10T16:28Z
...

$ open http://localhost:9874
```