### PR TITLE
HDDS-6187. Publish docker image for Ozone 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20210520-1
-ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0.tar.gz
+FROM apache/ozone-runner:20211202-1
+ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.1/ozone-1.2.1.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -31,4 +31,4 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build --build-arg OZONE_URL -t apache/ozone $@ .
-docker tag apache/ozone apache/ozone:1.2.0
+docker tag apache/ozone apache/ozone:1.2.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:1.2.0
+      image: apache/ozone:1.2.1
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:1.2.0
+      image: apache/ozone:1.2.1
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:1.2.0
+      image: apache/ozone:1.2.1
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:1.2.0
+      image: apache/ozone:1.2.1
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:1.2.0
+      image: apache/ozone:1.2.1
       ports:
          - 9878:9878
       env_file:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update dockerfile etc. for building with version 1.2.1.

https://issues.apache.org/jira/browse/HDDS-6187

## How was this patch tested?

Built locally:

```
$ ./build.sh
...
 => [ 3/10] RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz https://dlcdn.apache.org/ozone/1.2.1/ozone-1.2.1.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
...
```

Tested:

```
$ docker-compose up -d --scale datanode=3
$ docker-compose exec om ozone version
...
              /    1.2.1(Glacier)

Source code repository https://github.com/apache/ozone.git -r 76aa27e7c05196ae00cba540efce4bb7529e5d15
Compiled by ethanrose on 2021-12-15T22:28Z
...

$ open http://localhost:9874
```