### PR TITLE
HDDS-7698. Update dockerfile for ozone 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20211202-1
-ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.2.1/ozone-1.2.1.tar.gz
+FROM apache/ozone-runner:20220623-1
+ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.3.0/ozone-1.3.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -19,9 +19,9 @@ set -eu
 mkdir -p build
 if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
   if type wget 2> /dev/null; then
-    wget "https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+    wget "https://archive.apache.org/dist/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
   elif type curl 2> /dev/null; then
-    curl -LSs "https://dlcdn.apache.org/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+    curl -LSs "https://archive.apache.org/dist/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
   else
     exit 1
   fi
@@ -31,4 +31,4 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
 fi
 java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
 docker build --build-arg OZONE_URL -t apache/ozone $@ .
-docker tag apache/ozone apache/ozone:1.2.1
+docker tag apache/ozone apache/ozone:1.3.0

--- a/build.sh
+++ b/build.sh
@@ -17,11 +17,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -eu
 mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
+if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
   if type wget 2> /dev/null; then
-    wget "https://archive.apache.org/dist/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+    wget "https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
   elif type curl 2> /dev/null; then
-    curl -LSs "https://archive.apache.org/dist/creadur/apache-rat-0.13/apache-rat-0.13-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+    curl -LSs "https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
   else
     exit 1
   fi
@@ -29,6 +29,6 @@ if [ ! -d "$DIR/build/apache-rat-0.13" ]; then
   tar zvxf apache-rat.tar.gz
   cd -
 fi
-java -jar $DIR/build/apache-rat-0.13/apache-rat-0.13.jar $DIR -e .dockerignore -e public -e apache-rat-0.13 -e .git -e .gitignore
+java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e .dockerignore -e public -e apache-rat-0.15 -e .git -e .gitignore
 docker build --build-arg OZONE_URL -t apache/ozone $@ .
 docker tag apache/ozone apache/ozone:1.3.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:1.2.1
+      image: apache/ozone:1.3.0
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:1.2.1
+      image: apache/ozone:1.3.0
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:1.2.1
+      image: apache/ozone:1.3.0
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:1.2.1
+      image: apache/ozone:1.3.0
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:1.2.1
+      image: apache/ozone:1.3.0
       ports:
          - 9878:9878
       env_file:


### PR DESCRIPTION
### **What changes were proposed in this pull request?**
Update dockerfile for ozone 1.3.0.

https://issues.apache.org/jira/browse/HDDS-7698

### **How was this patch tested?**
**Built locally:**

$ ./build.sh
...
 => [ 3/10] RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz https://dlcdn.apache.org/ozone/1.3.0/ozone-1.3.0.tar.gz && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
...


**Tested:**
$ docker-compose disable-v2
$ docker-compose up -d --scale datanode=3
$ docker-compose exec om ozone version
...
              /    1.3.0(Grand Canyon)

Source code repository https://github.com/apache/ozone.git -r d0d18a3bff64b90f5f0755edb6003301049ffb32
Compiled by micahzhao on 2022-12-10T13:24Z
Compiled with protoc 2.5.0, 3.19.2 and 3.7.1
From source with checksum a75ae3e67172919e2714f238d9cc67a
With Apache Ratis: 2.4.0 from 48cba75f6458900ff7365dcdcc76242442b7b004
...


Wait a few minutes for the cluster initialization to complete：
$ open http://localhost:9874