### PR TITLE
HDDS-10167. Publish docker image for Ozone 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20220623-1
-ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.3.0/ozone-1.3.0.tar.gz
+FROM apache/ozone-runner:20230615-1
+ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.4.0/ozone-1.4.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 WORKDIR /opt/hadoop

--- a/build.sh
+++ b/build.sh
@@ -15,13 +15,19 @@
 # limitations under the License.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 set -eu
+
 mkdir -p build
-if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
+
+ozone_version=1.4.0
+rat_version=0.16
+
+if [ ! -d "$DIR/build/apache-rat-${rat_version}" ]; then
   if type wget 2> /dev/null; then
-    wget "https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
+    wget "https://dlcdn.apache.org/creadur/apache-rat-${rat_version}/apache-rat-${rat_version}-bin.tar.gz" -O "$DIR/build/apache-rat.tar.gz"
   elif type curl 2> /dev/null; then
-    curl -LSs "https://dlcdn.apache.org/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
+    curl -LSs "https://dlcdn.apache.org/creadur/apache-rat-${rat_version}/apache-rat-${rat_version}-bin.tar.gz" -o "$DIR/build/apache-rat.tar.gz"
   else
     exit 1
   fi
@@ -29,6 +35,8 @@ if [ ! -d "$DIR/build/apache-rat-0.15" ]; then
   tar zvxf apache-rat.tar.gz
   cd -
 fi
-java -jar $DIR/build/apache-rat-0.15/apache-rat-0.15.jar $DIR -e .dockerignore -e public -e apache-rat-0.15 -e .git -e .gitignore
+
+java -jar $DIR/build/apache-rat-${rat_version}/apache-rat-${rat_version}.jar $DIR -e .dockerignore -e public -e apache-rat-${rat_version} -e .git -e .gitignore
+
 docker build --build-arg OZONE_URL -t apache/ozone $@ .
-docker tag apache/ozone apache/ozone:1.3.0
+docker tag apache/ozone apache/ozone:${ozone_version}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:1.3.0
+      image: apache/ozone:1.4.0
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:1.3.0
+      image: apache/ozone:1.4.0
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:1.3.0
+      image: apache/ozone:1.4.0
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:1.3.0
+      image: apache/ozone:1.4.0
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:1.3.0
+      image: apache/ozone:1.4.0
       ports:
          - 9878:9878
       env_file:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Dockerfile etc. for building with version 1.4.0.

Bump Rat to 0.16.

https://issues.apache.org/jira/browse/HDDS-10167

## How was this patch tested?

Built locally:

```
$ ./build.sh
...
Successfully built 0094eca60d83
Successfully tagged apache/ozone:latest
```

Verified Ozone version:

```
$ docker run -it --rm apache/ozone:1.4.0 ozone version
...
              /    1.4.0(Hot Springs)

Source code repository https://github.com/apache/ozone.git -r e4b6007c8e9f79d1432cf6f128d6f83e733f8e9b
Compiled by ozone on 2024-01-10T15:32Z
...
```

Tested:

```
$ docker-compose up -d --scale datanode=3
$ docker-compose exec om ozone admin safemode wait
...
SCM is out of safe mode.

$ docker-compose exec om ozone version
...
              /    1.4.0(Hot Springs)
...

$ open http://localhost:9874

$ docker-compose exec -T scm ozone freon ockg -n1 -t1 -p test
...
2024-01-19 17:36:24 INFO  RpcClient:452 - Creating Volume: vol1, with hadoop as owner and space quota set to -1 bytes, counts quota set to -1
2024-01-19 17:36:24 INFO  RpcClient:679 - Creating Bucket: vol1/bucket1, with server-side default bucket layout, hadoop as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
2024-01-19 17:36:26 INFO  metrics:107 - type=TIMER, name=key-create, count=1, min=786.948162, max=786.948162, mean=786.948162, stddev=0.0, median=786.948162, p75=786.948162, p95=786.948162, p98=786.948162, p99=786.948162, p999=786.948162, mean_rate=0.6392560001143501, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/second, duration_unit=milliseconds
2024-01-19 17:36:26 INFO  BaseFreonGenerator:75 - Total execution time (sec): 2
2024-01-19 17:36:26 INFO  BaseFreonGenerator:75 - Failures: 0
2024-01-19 17:36:26 INFO  BaseFreonGenerator:75 - Successful executions: 1
```