### PR TITLE
HDDS-11204. Update repo link and description

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Repository for building Apache Ozone Docker images"
+  homepage: https://ozone.apache.org
+  labels:
+    - ozone
+    - container
+  autolink_jira:
+    - HDDS
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label worklog


### PR DESCRIPTION
## What changes were proposed in this pull request?

This [repo](https://github.com/apache/ozone-docker)'s description and link are outdated:

> Repository for building Apache Hadoop Ozone Docker images
> https://hadoop.apache.org/

Add `.asf.yaml` with updated link, tags, and slightly updated description.

It also auto-links HDDS issues from Github to Jira.

https://issues.apache.org/jira/browse/HDDS-11204

## How was this patch tested?

Tested in other repos, e.g. `ozone-docker-runner` already has `.asf.yaml`.