### PR TITLE
HDDS-11329. Update Ozone images to Rocky Linux-based runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20230615-1
+FROM apache/ozone-runner:20240729-jdk17-1
 ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.4.0/ozone-1.4.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ set -eu
 mkdir -p build
 
 ozone_version=1.4.0
-rat_version=0.16
+rat_version=0.16.1
 
 if [ ! -d "$DIR/build/apache-rat-${rat_version}" ]; then
   if type wget 2> /dev/null; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `apache/ozone:1.4.0` to use the latest `apache/ozone-runner:20240729-jdk17-1` as base image.  It has Rocky Linux instead of CentOS (EOL) and comes with updated third-party software.

(Similar PRs for other Ozone versions will follow.)

## How was this patch tested?

- Built image locally.
- Started Docker Compose cluster and ran Freon.
- Ran Ozone's xcompat acceptance test.