### PR TITLE
HDDS-11632. Publish images to GitHub container repo

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build-and-tag
+
+# This workflow builds (if necessary) and tags the Docker image.
+# Images are tagged by extracting the version from branch name:
+#   ozone-X.Y -> X.Y
+
+on:
+  push:
+    branches:
+      - 'ozone-**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  tag:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      IMAGE_ID: ${{ needs.build.outputs.image-id }}
+      REGISTRIES: ghcr.io # docker.io is appended dynamically
+    steps:
+      - name: Generate tags
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ${{ github.repository_owner }}/ozone
+          tags: |
+            type=match,pattern=ozone-(.*),value={{branch}},group=1
+          flavor: |
+            latest=false
+
+      - name: Add Docker Hub to targets
+        if: ${{ env.DOCKERHUB_USER }}
+        run: |
+          echo "REGISTRIES=${{ env.REGISTRIES}} docker.io" >> $GITHUB_ENV
+
+      - name: Pull image
+        run: |
+          docker pull "$IMAGE_ID"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USER }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Apply tags to existing image
+        run: |
+          set -x
+          for registry in $REGISTRIES; do
+            opts="$(echo "$DOCKER_METADATA_OUTPUT_TAGS" | sed "s@^@--tag $registry/@g" | xargs echo)"
+            if [[ -n "$opts" ]]; then
+              docker buildx imagetools create $opts "$IMAGE_ID"
+            fi
+          done

--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Add Docker Hub to targets
         if: ${{ env.DOCKERHUB_USER }}
         run: |
-          echo "REGISTRIES=${{ env.REGISTRIES}} docker.io" >> $GITHUB_ENV
+          echo "REGISTRIES=${{ env.REGISTRIES }} docker.io" >> $GITHUB_ENV
 
       - name: Pull image
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build
+
+# This workflow builds the Docker image if it does not exists already.
+# For non-PR runs, it also publishes the image to the registry, tagging it by the full SHA of the commit.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  push:
+    branches-ignore:
+      - 'ozone-**'
+  workflow_call:
+    outputs:
+      image-id:
+        description: "Docker image ID in repo/owner/name:tag format"
+        value: ${{ jobs.build.outputs.image-id }}
+
+concurrency:
+  group: ${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-id: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Generate image ID
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/ozone
+          tags: |
+            # keep single item
+            # any further tags should be added only in build-and-tag.yaml, not here
+            type=sha,prefix=,format=long
+
+      - name: Check if image exists
+        id: pull
+        run: |
+          success=false
+          if docker pull "$DOCKER_METADATA_OUTPUT_TAGS"; then
+            success=true
+          fi
+
+          echo "success=$success" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
+      - name: Login to GitHub Container Registry
+        id: login
+        if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GitHub Container Registry
+        id: build
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Workflow to build and publish multi-platform `ozone` Docker image to GitHub Container Registry and Docker Hub.

- Pull request: image is built, but not published
- Push: image is built and published by commit SHA.
- Push to branch `ozone-X.Y`: the image is also published with Docker tag `X.Y`.  This matches current Docker Hub automated build rules.
- Similarly to `ozone-docker-runner`, push to Docker Hub is optional, only performed if credentials are available.

This PR is targeted at `latest`, which is like `main` for this repo.  After merge, we'll need to cherry-pick it to version-specific branches where we would like the workflow to be used.  We'll also need to ask Infra to disable the automated build at Docker Hub.

https://issues.apache.org/jira/browse/HDDS-11632

## How was this patch tested?

Push to branches:

- `HDDS-11632` ([workflow](https://github.com/adoroszlai/ozone-docker/actions/runs/11730671311), [image](https://github.com/adoroszlai/ozone-docker/pkgs/container/ozone/302215411?tag=2721d2e5503dfa7b797ff9bfc8e6f5c21fa487fc)).
- `ozone-test` ([workflow](https://github.com/adoroszlai/ozone-docker/actions/runs/11730787985), [image](https://github.com/adoroszlai/ozone-docker/pkgs/container/ozone/302215411?tag=test)).
- `ozone-test-with-dh` after adding Docker Hub credentials to the repo ([workflow](https://github.com/adoroszlai/ozone-docker/actions/runs/11730972980), image at [ghcr.io](https://github.com/adoroszlai/ozone-docker/pkgs/container/ozone/302215411?tag=test-with-dh) and [hub.docker.com](https://hub.docker.com/layers/adoroszlai/ozone/test-with-dh/images/sha256-e5d20b95e06eac5e6d5b6116e26d5689bed9c68d650167aac52fa122b5a048cd?context=repo))

(Note that the same commit was pushed to all branches, so tags `test` and `test-with-dh` refer to the same image.)