### PR TITLE
HDDS-11700. Use ozone-runner from GitHub in ozone image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  OZONE_RUNNER_IMAGE: ghcr.io/apache/ozone-runner
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -87,6 +90,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
+          build-args: OZONE_RUNNER_IMAGE
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner:20240729-jdk17-1
+ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
+FROM ${OZONE_RUNNER_IMAGE}:20241108-jdk17-1
+
 ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.4.0/ozone-1.4.0.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
+
 WORKDIR /opt/hadoop
 COPY log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 COPY ozone-site.xml /opt/hadoop/etc/hadoop/ozone-site.xml


### PR DESCRIPTION
## What changes were proposed in this pull request?

When building apache/ozone Docker image in GitHub workflow, pull ozone-runner from GitHub Container Registry instead of Docker Hub.

https://issues.apache.org/jira/browse/HDDS-11700

## How was this patch tested?

Verified base image in CI build:

```
#4 [linux/amd64 internal] load metadata for ghcr.io/apache/ozone-runner:20241108-jdk17-1
#4 DONE 1.2s

#2 [linux/arm64 internal] load metadata for ghcr.io/apache/ozone-runner:20241108-jdk17-1
#2 DONE 1.2s
```

https://github.com/adoroszlai/ozone-docker/actions/runs/11833939687/job/32973630196#step:7:220

Verified base image in local build without setting `OZONE_RUNNER_IMAGE`:

```
 => [internal] load metadata for docker.io/apache/ozone-runner:20241108-jdk17-1
```