### PR TITLE
HDDS-11767. Use closer.lua in Ozone images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
 FROM ${OZONE_RUNNER_IMAGE}:20241108-jdk17-1
 
-ARG OZONE_URL=https://dlcdn.apache.org/ozone/1.4.0/ozone-1.4.0.tar.gz
+ARG OZONE_VERSION=1.4.0
+ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
+
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o ozone.tar.gz $OZONE_URL && tar zxf ozone.tar.gz && rm ozone.tar.gz && mv ozone* hadoop
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most Ozone images download binaries from dlcdn.  They cannot be rebuilt after old releases are removed from mirrors.  Replace the URL with one that is supposed to work for both new and old binaries.

Also, extract version number to argument to reduce duplication.

https://issues.apache.org/jira/browse/HDDS-11767

## How was this patch tested?

Version that is currently mirrored:

```
$ curl -L --head "https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/1.4.0/ozone-1.4.0.tar.gz"
HTTP/2 302 
...
location: https://dlcdn.apache.org/ozone/1.4.0/ozone-1.4.0.tar.gz
...

HTTP/2 200 
...
content-length: 482009796
...
```

Archived version:

```
curl -L --head "https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/1.3.0/ozone-1.3.0.tar.gz"
HTTP/2 302 
...
location: https://archive.apache.org/dist/ozone/1.3.0/ozone-1.3.0.tar.gz
...

HTTP/1.1 200 OK
...
Content-Length: 427860880
...
```

CI build:
https://github.com/adoroszlai/ozone-docker/actions/runs/11947909528/job/33304613875#step:7:442