### PR TITLE
HDDS-11264. Publish docker image for Ozone 1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
 FROM ${OZONE_RUNNER_IMAGE}:20241108-jdk17-1
 
-ARG OZONE_VERSION=1.4.0
+ARG OZONE_VERSION=1.4.1
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
 
 WORKDIR /opt

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ set -eu
 
 mkdir -p build
 
-ozone_version=1.4.0
+ozone_version=1.4.1
 rat_version=0.16.1
 
 if [ ! -d "$DIR/build/apache-rat-${rat_version}" ]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,14 +17,14 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone:1.4.0
+      image: apache/ozone:1.4.1
       ports:
          - 9864
       command: ["ozone","datanode"]
       env_file:
          - ./docker-config
    om:
-      image: apache/ozone:1.4.0
+      image: apache/ozone:1.4.1
       ports:
          - 9874:9874
       environment:
@@ -34,7 +34,7 @@ services:
          - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone:1.4.0
+      image: apache/ozone:1.4.1
       ports:
          - 9876:9876
       env_file:
@@ -43,14 +43,14 @@ services:
          ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["ozone","scm"]
    recon:
-      image: apache/ozone:1.4.0
+      image: apache/ozone:1.4.1
       ports:
          - 9888:9888
       env_file:
          - ./docker-config
       command: ["ozone","recon"]
    s3g:
-      image: apache/ozone:1.4.0
+      image: apache/ozone:1.4.1
       ports:
          - 9878:9878
       env_file:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Dockerfile etc. for building with version 1.4.1.

https://issues.apache.org/jira/browse/HDDS-11264

## How was this patch tested?
### Build
```
$ ./build.sh
...

0 Unknown Licenses
...

 => exporting to image                                                                                                                             2.5s
 => => exporting layers                                                                                                                            2.5s
 => => writing image sha256:b48cc2782ecd188f1cfcb73bb7ed8dcdcecb7a1159398bdc85f4e96498e497ff                                                       0.0s
 => => naming to docker.io/apache/ozone   
```

### Verified Ozone version:
```
$ docker run -it --rm apache/ozone:1.4.1 ozone version
...
Using HDDS 1.4.1
Source code repository git@github.com:apache/ozone.git -r a9d5d1c630d903b28984d1c46daa78a1812674ac
Compiled by ozone on 2024-11-14T09:02Z
Compiled with protoc 2.5.0, 3.19.6 and 3.7.1
From source with checksum d22ed53365b414131a5cf153863ad62f
Compiled on platform osx-x86_64
```

### Test

```
$ docker-compose up -d --scale datanode=3
[+] Running 7/7
 ✔ Container ozone-docker-scm-1       Running                                                                                                      0.0s 
 ✔ Container ozone-docker-recon-1     Running                                                                                                      0.0s 
 ✔ Container ozone-docker-s3g-1       Running                                                                                                      0.0s 
 ✔ Container ozone-docker-datanode-1  Running                                                                                                      0.0s 
 ✔ Container ozone-docker-datanode-2  Running                                                                                                      0.0s 
 ✔ Container ozone-docker-datanode-3  Running                                                                                                      0.0s 
 ✔ Container ozone-docker-om-1        Started                                                                                                      0.5s 


$ docker exec -it ozone-docker-om-1 ozone version
...
Using HDDS 1.4.1
Source code repository git@github.com:apache/ozone.git -r a9d5d1c630d903b28984d1c46daa78a1812674ac
Compiled by ozone on 2024-11-14T09:02Z
Compiled with protoc 2.5.0, 3.19.6 and 3.7.1
From source with checksum d22ed53365b414131a5cf153863ad62f
Compiled on platform osx-x86_64


$ docker exec -it ozone-docker-om-1 ozone freon ockg -n1 -t1 -p test
...
Total execution time (sec): 3
Failures: 0
Successful executions: 1
```


