### PR TITLE
HDDS-12153. Rebase 1.4.x images on top of ozone-runner with JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
-FROM ${OZONE_RUNNER_IMAGE}:20241108-jdk17-1
+FROM ${OZONE_RUNNER_IMAGE}:20241212-1-jdk11
 
 ARG OZONE_VERSION=1.4.1
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone 1.4.x does not fully support JDK17: services work, but some CLI uses GSON, which does not (see HDDS-10538).  So images for 1.4.x should use Java 11.

https://issues.apache.org/jira/browse/HDDS-12153

## How was this patch tested?

Image built in CI:
https://github.com/adoroszlai/ozone-docker/actions/runs/13027213850

Tested in cluster started with [`docker-compose.yaml`](https://raw.githubusercontent.com/apache/ozone-docker/b2148701a20454fd41176aa6f75697c0b1f18a5b/docker-compose.yaml) from `latest` branch, slightly edited:

```diff
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-1.4.1}${OZONE_IMAGE_FLAVOR:--rocky}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-1.4.1}${OZONE_IMAGE_FLAVOR:-}
```

```bash
export OZONE_IMAGE=ghcr.io/adoroszlai/ozone
export OZONE_IMAGE_VERSION=8ed8e020dc69b2c6ed53a5a31cafc2af161876e2
docker compose up -d --scale datanode=3
docker compose exec -T scm bash <<EOF
ozone sh volume create /vol1
ozone sh bucket create /vol1/bucket1
ozone sh key put /vol1/bucket1/passwd /etc/passwd
ozone debug chunkinfo /vol1/bucket1/passwd
EOF
```

```
{
  "KeyLocations": [
    [
      {
        "Datanode-HostName": "docker-ozone-datanode-2.docker-ozone_default",
        "Datanode-IP": "192.168.144.7",
        "Container-ID": 3,
        "Block-ID": 115816896921600003,
        "Locations": {
          "files": [
            "/data/hdds/hdds/CID-f3fe8fe6-5ae9-461c-98f6-1cc35961ebe4/current/containerDir0/3/chunks/115816896921600003.block"
          ],
          "pipelineID": "329e11c2-0519-4c42-87cf-d167719e0ec0"
        }
      },
      ...
    ]
  ]
}
```