### PR TITLE
HDDS-12167. Cannot use sample compose definition with SHA-based image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@
 
 x-image:
    &image
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-1.4.1}${OZONE_IMAGE_FLAVOR:--rocky}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-1.4.1}${OZONE_IMAGE_FLAVOR:-}
 
 x-common-config:
    &common-config


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sample `docker-compose.yaml` sets `OZONE_IMAGE_FLAVOR` to `-rocky`, if unset or empty.  This makes it cumbersome to use the definition with images identified by commit SHA.  Straightforward way results in error:

```
export OZONE_IMAGE=ghcr.io/adoroszlai/ozone
export OZONE_IMAGE_VERSION=8ed8e020dc69b2c6ed53a5a31cafc2af161876e2
export OZONE_IMAGE_FLAVOR=""
docker compose up -d --scale datanode=3
...
Error response from daemon: manifest unknown
```

Possible workaround: splitting the SHA value between `OZONE_IMAGE_VERSION` and `OZONE_IMAGE_FLAVOR` as:

```
export OZONE_IMAGE_VERSION=8ed8e020dc69b2c6ed53a5a31cafc2af161876
export OZONE_IMAGE_FLAVOR=e2
```

Since we plan to publish images also without `-rocky` suffix anyway, and all existing images are available both with and without (although those without it may be outdated, except 1.4.1), I think it's safe to make flavor optional (use empty value by default).

https://issues.apache.org/jira/browse/HDDS-12167

## How was this patch tested?

```
$ OZONE_IMAGE=ghcr.io/adoroszlai/ozone
$ OZONE_IMAGE_VERSION=8ed8e020dc69b2c6ed53a5a31cafc2af161876e2

$ docker compose up -d --scale datanode=3
[+] Running 7/8
 ⠏ Network docker-ozone_default       Created
 ✔ Container docker-ozone-scm-1       Started
 ✔ Container docker-ozone-recon-1     Started
 ✔ Container docker-ozone-s3g-1       Started
 ✔ Container docker-ozone-datanode-2  Started
 ✔ Container docker-ozone-om-1        Started
 ✔ Container docker-ozone-datanode-1  Started
 ✔ Container docker-ozone-datanode-3  Started
```
