### PR TITLE
HDDS-11522. Publish Ozone 2.0 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
-ARG OZONE_RUNNER_VERSION=20241212-1-jdk21
+ARG OZONE_RUNNER_VERSION=20250410-1-jdk21
 FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
-ARG OZONE_VERSION=1.4.1
+ARG OZONE_VERSION=2.0.0
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
 
 WORKDIR /opt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@
 
 x-image:
    &image
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-1.4.1}${OZONE_IMAGE_FLAVOR:-}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.0.0}${OZONE_IMAGE_FLAVOR:-}
 
 x-common-config:
    &common-config


### PR DESCRIPTION
* Use the latest runner image 20250410-1-jdk21
* Updated OZONE_VERSION to 2.0.0

Built successfully locally.