### PR TITLE
HDDS-12931. [Ozone 2.0] Update ozone.scm.datanode.id.dir in the docker-compose.yaml of ozone-docker repo.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ x-common-config:
    OZONE-SITE.XML_ozone.replication: "1"
    OZONE-SITE.XML_ozone.scm.block.client.address: "scm"
    OZONE-SITE.XML_ozone.scm.client.address: "scm"
-   OZONE-SITE.XML_ozone.scm.datanode.id.dir: "/data"
+   OZONE-SITE.XML_ozone.scm.datanode.id.dir: "/data/metadata"
    OZONE-SITE.XML_ozone.scm.names: "scm"
    no_proxy: "om,recon,scm,s3g,localhost,127.0.0.1"
 


### PR DESCRIPTION
Apache JIRA: https://issues.apache.org/jira/browse/HDDS-12931

Make the docker-compose.yaml configuration consistent with the ones in the main ozone repo. See #7402 (arguably a breaking change)

We should update ozone-latest, ozone-2.0.0, ozone-2.0.0-rocky branches/images as well.