### PR TITLE
HDDS-14358. Publish Ozone 2.1 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
-ARG OZONE_RUNNER_VERSION=20250410-1-jdk21
+ARG OZONE_RUNNER_VERSION=20260106-1-jdk21
 FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
-ARG OZONE_VERSION=2.0.0
+ARG OZONE_VERSION=2.1.0
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
 
 WORKDIR /opt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@
 
 x-image:
    &image
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.0.0}${OZONE_IMAGE_FLAVOR:-}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.0}${OZONE_IMAGE_FLAVOR:-}
 
 x-common-config:
    &common-config


### PR DESCRIPTION
Done in this pr: 
1. Use the latest runner image 20260106-1-jdk21
2. Updated OZONE_VERSION to 2.1.0

ci: https://github.com/chungen0126/ozone-docker/actions/runs/20752794353