### PR TITLE
HDDS-9698. Skip push build for dependabot

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ on:
     types: [opened, ready_for_review, synchronize]
   push:
     branches-ignore:
+      - 'dependabot/**'
       - 'ozone-**'
   workflow_call:
     outputs:


### PR DESCRIPTION
## What changes were proposed in this pull request?

dependabot pushes dependency version bumps to the main repo instead of its own fork.  It then creates a pull request without waiting for the `push` workflow to succeed.  Thus both workflows test the same state of code, which is unnecessary.

I propose completely skipping `push` build for dependabot's changes to save CI resources.

https://issues.apache.org/jira/browse/HDDS-9698

## How was this patch tested?

Same setting already used in Apache Ratis CI.