### PR TITLE
HDDS-15576. Update Docker image for Ozone 2.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
 ARG OZONE_RUNNER_VERSION=20260206-2-jdk21
 FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
-ARG OZONE_VERSION=2.1.0
+ARG OZONE_VERSION=2.1.1
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
 
 WORKDIR /opt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@
 
 x-image:
    &image
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.0}${OZONE_IMAGE_FLAVOR:-}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.1}${OZONE_IMAGE_FLAVOR:-}
 
 x-common-config:
    &common-config


### PR DESCRIPTION
* The latest branch is already using the latest runner image 20260206-2-jdk21
* Updated OZONE_VERSION to 2.1.0