### PR TITLE
HDDS-15719. Add check for allowed action usage in workflows

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "ASF Allowlist Check"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check actions
+        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3
+        with:
+          scan-glob: ".github/workflows/*.y*ml"


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflows may fail silently when using any actions not allowed by ASF Infra.  See https://github.com/apache/infrastructure-actions/issues/574 for details.

This change adds a new check that verifies action usage in workflows.  See https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md

https://issues.apache.org/jira/browse/HDDS-15719

## How was this patch tested?

asf-allowlist-check: https://github.com/adoroszlai/ozone-docker/actions/runs/28707803583/job/85136272854#step:3:30

```
Checking 8 unique action ref(s) against the ASF allowlist:

  ✅ actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 — trusted owner (actions)  (.github/workflows/asf-allowlist-check.yaml, .github/workflows/zizmor.yml)
  ✅ apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3 — trusted owner (apache)  (.github/workflows/asf-allowlist-check.yaml)
  ✅ docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf — matches allowlist  (.github/workflows/build.yaml)
  ✅ docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee — matches allowlist  (.github/workflows/build-and-tag.yaml, .github/workflows/build-and-tag.yaml, .github/workflows/build.yaml)
  ✅ docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 — matches allowlist  (.github/workflows/build-and-tag.yaml, .github/workflows/build.yaml)
  ✅ docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 — matches allowlist  (.github/workflows/build.yaml)
  ✅ docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 — matches allowlist  (.github/workflows/build.yaml)
  ✅ zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa — matches allowlist  (.github/workflows/zizmor.yml)
All 8 unique action refs are on the ASF allowlist
```

zizmor: https://github.com/adoroszlai/ozone-docker/actions/runs/28707803568/job/85136272919#step:3:93
