### PR TITLE
HDDS-16108. Update Docker image for Ozone 2.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG OZONE_RUNNER_IMAGE=apache/ozone-runner
 ARG OZONE_RUNNER_VERSION=20260626-1-jdk21
 FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
-ARG OZONE_VERSION=2.2.0
+ARG OZONE_VERSION=2.2.1
 ARG OZONE_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=ozone/${OZONE_VERSION}/ozone-${OZONE_VERSION}.tar.gz"
 
 WORKDIR /opt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@
 
 x-image:
    &image
-   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.2.0}${OZONE_IMAGE_FLAVOR:-}
+   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.2.1}${OZONE_IMAGE_FLAVOR:-}
 
 x-common-config:
    &common-config


### PR DESCRIPTION
## Summary
- Bump default Ozone version to 2.2.1 in `Dockerfile` and `docker-compose.yaml`

## Jira
https://issues.apache.org/jira/browse/HDDS-16108

## After merge
Fast-forward and push version branches to trigger publish:
- `ozone-2.2.1`
- `ozone-2.2.1-rocky`
- `ozone-2.2.1-slim`
- `ozone-2.2.1-all-in-one`

## Test plan
- [ ] CI passes on PR
- [ ] After tag branches pushed, verify `docker pull apache/ozone:2.2.1-rocky`


Made with [Cursor](https://cursor.com)